### PR TITLE
Use markdownify feature in tabset example

### DIFF
--- a/content/learn/seedling/index.md
+++ b/content/learn/seedling/index.md
@@ -12,28 +12,29 @@ categories:
 ---
 
 Courtesy of panelset.js by Garrick Aden-Buie, from his xaringanExtra package: https://pkg.garrickadenbuie.com/xaringanExtra/#/panelset
+adapted into [Hugo Shortcodes](https://gohugo.io/content-management/shortcodes/)
 
 For example, this panelset:
 
 {{< panelset class="greetings" >}}
-{{< panel name="Hello! :wave:" >}}
-  hello
-{{< /panel >}}
-{{< panel name="Goodbye :dash:" >}}
+{{% panel name="Hello! :wave:" %}}
+  __Hello__ ! You can put `markdown` content, it will be nicely rendered :smile:
+{{% /panel %}}
+{{% panel name="Goodbye :dash:" %}}
   goodbye
-{{< /panel >}}
+{{% /panel %}}
 {{< /panelset  >}}
 
 Was created by combining this theme's `panelset` and `panel` shortcodes:
 
 ```go
 {{</* panelset class="greetings" */>}}
-{{</* panel name="Hello! :wave:" */>}}
-  hello
-{{</* /panel */>}}
-{{</* panel name="Goodbye :dash:" */>}}
+{{% panel name="Hello! :wave:" %}}
+  __Hello__ ! You can put `markdown` content, it will be nicely rendered :smile:
+{{% /panel %}}
+{{% panel name="Goodbye :dash:" %}}
   goodbye
-{{</* /panel */>}}
+{{% /panel %}}
 {{</* /panelset */>}}
 ```
 


### PR DESCRIPTION
Hi, I just discovered `Apero` which is a really beautiful `Hugo` framework.

I really love your `tabset` implementation that is really useful ! 

I am proposing you a PR to show the `{{% shortcodename parameters %}}` syntax rather than the `{{< shortcodename parameters >}}` . I think this is more useful to show that you can put markdown inside tabs, content will be nicely rendered.

Thus, I propose to replace `{{< panel  XXXX >}}`  by `{{% panel  XXXX %}}`. I let `{{< panelset  XXXX >}}` syntax because markdowinfication is not necessary at this level (since everything is markdownified inside panels) 
