### PR TITLE
Fixed 404 ERROR in "About" page.

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -6,7 +6,7 @@ show_header: true
 sidebar_left: true
 # Keep this! Do not edit.
 cascade:
-  headless: true
+  headless: false
 ---
 
 ** index doesn't contain a body, just front matter above.


### PR DESCRIPTION
When launching the website in RStudio, i was facing a 404 error message when clicked in the **About** menu header.

![headless is true](https://github.com/hugo-apero/hugo-apero-docs/assets/101839061/2ee9cca5-672c-47c6-8508-32e41a3ebbf8)


Searching the solution of this problem in the files, i was wondering where the problem could be, possibily in the path of the files, or some value in the **_index.md** file, in the path: /content/about. Changing the **Headless = false**, the error page will change for the predefined **About** page.

![headless is false](https://github.com/hugo-apero/hugo-apero-docs/assets/101839061/6072e783-de76-4f7f-a16a-740241c0a21e)
